### PR TITLE
Implement fusion strategies with aligned sample IDs

### DIFF
--- a/R/fusion.R
+++ b/R/fusion.R
@@ -8,21 +8,54 @@ grf_fuse <- function(task, mode = c("early","late","hybrid")){
   enc <- task$encodings
   if (length(enc) == 0) stop("call grf_encode() first")
 
-  task_ids <- rownames(MultiAssayExperiment::colData(task$mae))
-  aligned <- purrr::imap(enc, function(tbl, nm){
-    grf_align_encoding(tbl, nm, task_ids)
+  id_lists <- purrr::imap(enc, function(tbl, nm){
+    if (!"..rowid.." %in% names(tbl)) {
+      stop("Encoded modality '", nm, "' is missing the `..rowid..` column")
+    }
+    as.character(tbl$`..rowid..`)
   })
 
-  combined <- purrr::reduce(aligned, function(acc, tbl){
-    dplyr::full_join(acc, tbl, by = "..rowid..")
-  })
-  combined <- combined[, c("..rowid..", setdiff(names(combined), "..rowid..")), drop = FALSE]
-
-  if (mode == "early"){
-    task$fusion <- list(mode = mode, X = combined, per_modality = NULL)
-  } else {
-    task$fusion <- list(mode = mode, X = combined, per_modality = aligned)
+  common_ids <- id_lists[[1]]
+  if (length(common_ids) == 0) {
+    stop("No common sample identifiers across encoded modalities")
   }
+  if (length(id_lists) > 1) {
+    for (ids in id_lists[-1]) {
+      common_ids <- common_ids[common_ids %in% ids]
+    }
+  }
+  common_ids <- as.character(common_ids)
+  if (length(common_ids) == 0) {
+    stop("No common sample identifiers across encoded modalities")
+  }
+
+  aligned <- purrr::imap(enc, function(tbl, nm){
+    grf_align_encoding(tbl, nm, common_ids)
+  })
+
+  combined <- NULL
+  if (mode %in% c("early", "hybrid")) {
+    prefixed <- purrr::imap(aligned, function(tbl, nm){
+      feature_cols <- setdiff(names(tbl), "..rowid..")
+      if (!length(feature_cols)) {
+        return(tbl)
+      }
+      renamed <- tbl
+      idx <- match(feature_cols, names(renamed))
+      names(renamed)[idx] <- paste0(nm, "__", feature_cols)
+      renamed
+    })
+    combined <- purrr::reduce(prefixed, function(acc, tbl){
+      dplyr::full_join(acc, tbl, by = "..rowid..")
+    })
+    combined <- combined[, c("..rowid..", setdiff(names(combined), "..rowid..")), drop = FALSE]
+  }
+
+  task$fusion <- list(
+    mode = mode,
+    X = if (mode == "late") NULL else combined,
+    per_modality = if (mode == "early") NULL else aligned
+  )
   task$fit <- NULL
   task
 }
@@ -32,12 +65,21 @@ grf_align_encoding <- function(tbl, modality, ids){
   if (!"..rowid.." %in% names(tbl)) {
     stop("Encoded modality '", modality, "' is missing the `..rowid..` column")
   }
-  tbl <- dplyr::mutate(tbl, `..rowid..` = as.character(`..rowid..`))
-  feature_cols <- setdiff(names(tbl), "..rowid..")
-  if (length(feature_cols)) {
-    tbl <- dplyr::rename_with(tbl, ~paste0(modality, "__", .x), .cols = feature_cols)
+
+  tbl <- tibble::as_tibble(tbl)
+  tbl$`..rowid..` <- as.character(tbl$`..rowid..`)
+  tbl <- tbl[tbl$`..rowid..` %in% ids, , drop = FALSE]
+
+  ord <- match(ids, tbl$`..rowid..`)
+  if (anyNA(ord)) {
+    missing_ids <- ids[is.na(ord)]
+    stop(
+      "Encoded modality '", modality, "' is missing samples required for fusion: ",
+      paste(missing_ids, collapse = ", ")
+    )
   }
-  scaffold <- tibble::tibble(`..rowid..` = ids)
-  joined <- dplyr::left_join(scaffold, tbl, by = "..rowid..")
-  tibble::as_tibble(joined)
+
+  aligned <- tbl[ord, , drop = FALSE]
+  aligned <- aligned[, c("..rowid..", setdiff(names(aligned), "..rowid..")), drop = FALSE]
+  tibble::as_tibble(aligned)
 }


### PR DESCRIPTION
## Summary
- update `grf_fuse()` to intersect sample identifiers before combining modality encodings
- support early, late, and hybrid fusion outputs while prefixing fused feature names by modality
- expand tests to cover fusion structures and ensure only shared samples are retained

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd51a74f74832a9dd9c77bd7b550c9